### PR TITLE
fix: migrate dry-run-renovate workflow from pnpm to npm

### DIFF
--- a/.github/workflows/dry-run-renovate.yaml
+++ b/.github/workflows/dry-run-renovate.yaml
@@ -18,23 +18,19 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        if: hashFiles('package.json') != ''
-        uses: pnpm/action-setup@v4
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
 
       - name: Install Renovate CLI
-        run: pnpm install renovate
+        run: npm install renovate
 
       - name: Dry-run Renovate
         run: |
-          pnpm dlx renovate '${{ github.repository }}' \
+          npx renovate '${{ github.repository }}' \
             --dry-run=full \
             --use-base-branch-config=merge
         env:


### PR DESCRIPTION
## Summary

- Remove `pnpm/action-setup` step
- Switch Node.js cache from `pnpm` / `pnpm-lock.yaml` to `npm` / `package-lock.json`
- Replace `pnpm install` with `npm install` and `pnpm dlx` with `npx`

## Test plan

- [ ] dry-run-renovate workflow runs successfully on PR targeting master

🤖 Generated with [Claude Code](https://claude.com/claude-code)